### PR TITLE
Include support for dotnet8

### DIFF
--- a/Infragistics.QueryBuilder.Executor.csproj
+++ b/Infragistics.QueryBuilder.Executor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Infragistics.QueryBuilder.Executor</PackageId>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 ﻿# Infragistics.QueryBuilder.Executor
 
-A .NET 9 library for dynamic, strongly-typed query building and execution over Entity Framework Core data sources. Supports advanced filtering, projection, and SQL generation.
+A .NET 8, .NET 9 library for dynamic, strongly-typed query building and execution over Entity Framework Core data sources. Supports advanced filtering, projection, and SQL generation.
 
 [![NuGet](https://img.shields.io/nuget/v/Infragistics.QueryBuilder.Executor.svg)](https://www.nuget.org/packages/Infragistics.QueryBuilder.Executor/)
 
@@ -61,9 +61,10 @@ In your `Startup.cs` or Program configuration:
 
 ## Dependencies
 
-- .NET 9
+- .NET 8 or .NET 9
 - Microsoft.EntityFrameworkCore
 - AutoMapper
+- builder.Services.AddControllers().AddNewtonsoftJson(o => o.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore) for working SwaggerUI
 
 ---
 

--- a/Services/QueryBuilderService.cs
+++ b/Services/QueryBuilderService.cs
@@ -34,7 +34,7 @@ namespace Infragistics.QueryBuilder.Executor
                 ?? throw new InvalidOperationException($"DbSet '{propInfo.Name}' does not support AsQueryable().");
 
             var propRes = QueryExecutor.InvokeRunMethod([dbGenericType, dtoGenericType], [queryable, query, mapper]);
-            return new Dictionary<string, object[]> { { propInfo.Name.ToLowerInvariant(), propRes } };
+            return new Dictionary<string, object[]> { { query.Entity, propRes } };
         }
     }
 }


### PR DESCRIPTION
Add support for query builder package to dotnet8
Updated readme file, added 
`builder.Services.AddControllers().AddNewtonsoftJson(o => o.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore);
`
as dependency as it is needed for working SwaggerUI
Resolving task #38683
