### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/IgniteUI/Infragistics.QueryBuilder.Executor/security/code-scanning/1](https://github.com/IgniteUI/Infragistics.QueryBuilder.Executor/security/code-scanning/1)

To resolve the issue, an explicit `permissions` block needs to be added, either at the global workflow level (affecting all jobs) or at the job level (within the `build` job). Since the workflow does not perform any actions that require write permission—for example, creating issues, publishing packages, or interacting with pull requests—the most appropriate and secure setting is to use read-only access for repository contents: `permissions: { contents: read }`. This should be inserted near the top of the file, after the workflow `name` and before or after the `on` block for clarity, but before defining any jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
