### PR TITLE
change search value type to object

### DIFF
--- a/Model/QueryFilter.cs
+++ b/Model/QueryFilter.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Nodes;
-
-namespace Infragistics.QueryBuilder.Executor
+﻿namespace Infragistics.QueryBuilder.Executor
 {
     public class QueryFilter
     {
@@ -11,7 +9,7 @@ namespace Infragistics.QueryBuilder.Executor
 
         public QueryFilterCondition? Condition { get; set; }
 
-        public JsonValue? SearchVal { get; set; }
+        public object? SearchVal { get; set; }
 
         public Query? SearchTree { get; set; }
 

--- a/QueryExecutor.cs
+++ b/QueryExecutor.cs
@@ -257,8 +257,14 @@ namespace Infragistics.QueryBuilder.Executor
             return property.GetMemberValue(obj);
         }
 
-        private static Expression GetSearchValue(JsonValue? jsonVal, Type targetType)
+        private static Expression GetSearchValue(object? searchValue, Type targetType)
         {
+            if (searchValue == null)
+            {
+                return GetEmptyValue(targetType);
+            }
+
+            var jsonVal = JsonValue.Create(searchValue);
             var valueKind = jsonVal?.GetValueKind();
             if (valueKind == null || valueKind == JsonValueKind.Null || valueKind == JsonValueKind.Undefined)
             {


### PR DESCRIPTION
CodeGen is not recognizing JsonValue for react/wc/blazor and generated code is failing for it. 